### PR TITLE
Fix argument validation and slice init

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,9 +30,9 @@ func init() {
 	flag.StringVar(&path, "f", "", "file to scan (if not using -p)")
 	flag.Parse()
 
-	if (pid == 0) || (!embeddedYara) || (path == "") {
-		flag.Usage()
-	}
+       if (pid == 0 && path == "") || (!embeddedYara && pattern == "") {
+               flag.Usage()
+       }
 }
 
 func main() {

--- a/procfs.go
+++ b/procfs.go
@@ -206,7 +206,7 @@ func NewProc(pid int) (Proc, error) {
 // ProcMaps reads from /proc/[pid]/maps to get the memory-mappings of the
 // process.
 func (p Proc) ProcMaps() ([]*ProcMap, error) {
-	var maps = make([]*ProcMap, 1)
+       var maps []*ProcMap
 	file, err := os.Open(p.fs.Path("maps"))
 	if err != nil {
 		return maps, err


### PR DESCRIPTION
## Summary
- fix CLI argument validation in `init`
- initialize proc maps slice properly

## Testing
- `go vet ./...` *(fails: Package yara not found)*
- `go test ./...` *(fails: Package 'yara' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840748568188325a5ece996881089df