### PR TITLE
Enable regex scanning on files

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,9 +36,9 @@ func init() {
 
 	flag.Parse()
 
-       if (pid == 0 && path == "") || (!embeddedYara && pattern == "") {
-               flag.Usage()
-       }
+	if (pid == 0 && path == "") || (!embeddedYara && pattern == "") {
+		flag.Usage()
+	}
 }
 
 func main() {
@@ -73,19 +73,23 @@ func main() {
 		return
 
 	} else {
-
-		procfs, err := NewFS(DefaultProcMountPoint)
-		if err != nil {
-			log.Fatalln(err)
-		}
-
-		proc, err := procfs.Proc(pid)
-		if err != nil {
-			log.Fatalln(err)
-		}
-
+		var err error
 		matcher := regexp.MustCompile(pattern)
-		err = MemSearch(proc, matcher, resultsCh)
+		if path != "" {
+			err = RegexSearchFile(path, matcher, resultsCh)
+		} else {
+			procfs, err := NewFS(DefaultProcMountPoint)
+			if err != nil {
+				log.Fatalln(err)
+			}
+
+			proc, err := procfs.Proc(pid)
+			if err != nil {
+				log.Fatalln(err)
+			}
+
+			err = MemSearch(proc, matcher, resultsCh)
+		}
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,12 @@ ito -p 123 -r '.{20}[D|d]roid.{20}'
 ...
 ```
 
+Regex searches can also be run on files.
+
+```go
+ito -f /path/to/file -r 'mysecret'
+```
+
 Or use baked-in yara rules to search for multiple things at once.
 ```go
 ito -p 123 -Y

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+func TestRegexSearchFile(t *testing.T) {
+	around = 0
+	only = false
+	tmpDir := t.TempDir()
+	path := tmpDir + "/sample.txt"
+	err := os.WriteFile(path, []byte("this is mysecret in here"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch := make(chan []*Result, 1)
+	matcher := regexp.MustCompile("mysecret")
+	go func() {
+		if err := RegexSearchFile(path, matcher, ch); err != nil {
+			t.Error(err)
+		}
+		close(ch)
+	}()
+	results := <-ch
+	if len(results) == 0 {
+		t.Fatal("expected result")
+	}
+	if results[0].Match == "" {
+		t.Error("empty match")
+	}
+}


### PR DESCRIPTION
## Summary
- allow regex searches with `-f` without `-Y`
- implement `RegexSearchFile`
- document regex file scanning
- add unit test for file scanning

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68408b9253988325afe67e0695a3b695